### PR TITLE
add parenthesis to _print_ and use method _warning_ instead of _warn_

### DIFF
--- a/collective/watcherlist/mailer.py
+++ b/collective/watcherlist/mailer.py
@@ -35,14 +35,14 @@ def simple_send_mail(message, addresses, subject, immediate=False):
     """
     mail_host = utils.get_mail_host()
     if mail_host is None:
-        logger.warn("Cannot send notification email: please configure "
-                    "MailHost correctly.")
+        logger.warning("Cannot send notification email: please configure "
+                       "MailHost correctly.")
         # We print some info, which is perfect for checking in unit
         # tests.
-        print 'Subject =', subject
-        print 'Addresses =', addresses
-        print 'Message ='
-        print message
+        print('Subject =', subject)
+        print('Addresses =', addresses)
+        print('Message =')
+        print(message)
         return
 
     mfrom = utils.get_mail_from_address()


### PR DESCRIPTION
I was trying to install Products.Poi 4.0.2 on Plone 5.2 (python 3) and the installer complains that the syntax of `print ` is wrong.

Also, `logging.warn` seems to be [deprecated](https://docs.python.org/3.7/library/logging.html) in favor of `logging.warning`.